### PR TITLE
Fixes Slack new line characters

### DIFF
--- a/mirage/factories/ingredient.js
+++ b/mirage/factories/ingredient.js
@@ -1,9 +1,10 @@
 import Mirage, {faker} from 'ember-cli-mirage';
-​
+
 export default Mirage.Factory.extend({
   name() {
     return faker.hacker.phrase();
   },
+
   unit(id) {
     return [
       'cups',
@@ -11,8 +12,9 @@ export default Mirage.Factory.extend({
       'tablespoons',
     ][id % 3];
   },
-​
+
+
   quantity() {
     return faker.number(0, 4);
-  }
+  },
 });

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -1,10 +1,10 @@
 export default function(server) {
-​
-/*
+
+  /*
     Seed your development database using your factories.
     This data will not be loaded in your tests.
-*/
-​
+  */
+
   server.create('recipe', {ingredients: [1,2,3,4,5,6]});
   server.createList('ingredient', {recipe: 1});
 }


### PR DESCRIPTION
Looks like slack's new line characters were throwing things off.
